### PR TITLE
Updated dependencies, volumes, and a typo to consider

### DIFF
--- a/customer/src/ui/price.js
+++ b/customer/src/ui/price.js
@@ -3,7 +3,7 @@ import React from 'react';
 import '../styles/price.css';
 
 const Price = ({ price, style }) => (
-  <span className="price" style={{ ...style }}>{new Intl.NumberFormat('gb-GB', { style: 'currency', currency: 'EUR' }).format(price)}</span>
+  <span className="price" style={{ ...style }}>{new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(price)}</span>
 );
 
 export default Price;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - barq-server_barq-net
       # Ensure that node_modules aren’t unnecessarily copied
     volumes:
-     - ./admin:/app
+     - ./staff:/app
      - /app/node_modules
     # Set the container name
     ports:

--- a/staff/package.json
+++ b/staff/package.json
@@ -3,8 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "axios": "^0.18.0",
-    "qrcode.react": "^0.9.3",
+    "@material-ui/core": "^3.9.2",
+    "@material-ui/icons": "^3.0.2",
+    "axios": "^0.18.1",
+    "csvtojson": "^2.0.8",
+    "qrcode-react": "^0.1.16",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",

--- a/staff/src/containers/qrCode.js
+++ b/staff/src/containers/qrCode.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import QRCode from 'qrcode.react';
+import QRCode from 'qrcode-react';
 import '../styles/qrcode.css';
 
 class QrCode extends Component {  


### PR DESCRIPTION
I tried to get this working for myself, but was unable to do so without tweaking the dependencies so thought I'd contribute that change (updated qrcode.react to qrcode-react, added missing csvtojson and @material-ui, newer version of axios). 

I also changed the docker compose to reflect the correct volume for staff.

The typo to consider is the Intl.NumberFormat in price.js, set to 'gb-GB' but with a currency code of 'EUR'. I've resolved this as 'en-GB' and 'GBP' for my purposes, but you may wish to consider 'de-AT' for use with 'EUR'

Thanks for making this project available on the MIT license, I've learned a lot about React and Docker because of it. Apologies in advance if I've formed this PR incorrectly, it's my first time.